### PR TITLE
Fix URL decoding with newlines

### DIFF
--- a/src/main/java/application/SamlTabController.java
+++ b/src/main/java/application/SamlTabController.java
@@ -382,6 +382,7 @@ public class SamlTabController implements IMessageEditorTab, Observer {
 		}
 
 		String urlDecoded = helpers.urlDecode(message);
+		urlDecoded = urlDecoded.replaceAll("\\R", "");
 		byte[] base64Decoded = helpers.base64Decode(urlDecoded);
 
 		isInflated = true;


### PR DESCRIPTION
I noticed an issue decoding SAML assertions when the URL encoded message contained newlines. This is the case e.g. for swisspass.ch. This fix will remove any newlines in the URL encoded message before further processing.