### PR TITLE
Fixes some rendering issues in the cert tree

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ compileJava {
 }
 
 dependencies {
+	compileOnly libs.com.formdev.flatlaf
 	compileOnly libs.net.portswigger.burp.extensions.montoya.api
 	compileOnly libs.org.bouncycastle.bcpkix.jdk15on
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+com-formdev-flatlaf = "3.5.2"
 com-google-guava = "33.2.1-jre"
 com-miglayout = "3.7.4"
 com-sun-xml-security-xml-security-impl = "1.0"
@@ -9,6 +10,7 @@ org-junit-jupiter = "5.10.2"
 xerces-xercesimpl = "2.12.2"
 
 [libraries]
+com-formdev-flatlaf = { module = "com.formdev:flatlaf", version.ref = "com-formdev-flatlaf"}
 com-google-guava = { module = "com.google.guava:guava", version.ref = "com-google-guava"}
 com-miglayout =  { module = "com.miglayout:miglayout", version.ref = "com-miglayout" }
 com-sun-xml-security-xml-security-impl = { module = "com.sun.xml.security:xml-security-impl", version.ref = "com-sun-xml-security-xml-security-impl" }

--- a/src/main/java/gui/CertificateTab.java
+++ b/src/main/java/gui/CertificateTab.java
@@ -1,6 +1,7 @@
 package gui;
 
 import application.CertificateTabController;
+import com.formdev.flatlaf.ui.FlatTreeUI;
 import model.BurpCertificate;
 import model.BurpCertificateBuilder;
 import model.ObjectIdentifier;
@@ -146,6 +147,7 @@ public class CertificateTab extends JPanel {
 
         certificateTreeModel = new DefaultTreeModel(new DefaultMutableTreeNode("root"));
         certificateTree = new JTree(certificateTreeModel);
+        certificateTree.setUI(new FlatTreeUI());
         certificateTree.setRootVisible(false);
         certificateTree.setShowsRootHandles(true);
         certificateTree.setCellRenderer((tree, value, selected, expanded, leaf, row, hasFocus) -> {


### PR DESCRIPTION
Answer from Portswigger:

Hi Tobias

I'm sorry for the large delay in response.

I just wanted to let you know that we have looked into the JTree component further. JTrees are rendered differently in Burp because we have a custom UI delegate changing their appearance.

You can override this by setting the UI on the JTree component.

For example:
jTree.setUI(new BasicTreeUI());

Alternatively, if you would like to keep the theming more in line with Burps, you can import FlatLaf as a compile-time dependency and use "FlatTreeUI()" instead of "BasicTreeUI()".

Hope this helps!

Cheers

Hannah L (she/her)
Technical Product Specialist
PortSwigger