### PR TITLE
Fix null pointer with invalid xml

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,12 +2,12 @@ Uuid: c61cfa893bb14db4b01775554f7b802e
 ExtensionType: 1
 Name: SAML Raider
 RepoName: saml-raider
-ScreenVersion: 2.1.0
+ScreenVersion: 2.1.1
 SerialVersion: 18
 MinPlatformVersion: 0
 ProOnly: False
 Author: Roland Bischofberger / Emanuel Duss / Tobias Hort-Giess
 ShortDescription: Provides a SAML message editor and a certificate management tool to help with testing SAML infrastructures.
-EntryPoint: build/libs/saml-raider-2.1.0.jar
+EntryPoint: build/libs/saml-raider-2.1.1.jar
 BuildCommand: ./gradlew jar
 SupportedProducts: Pro, Community

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Don't forget to rate our extension with as many stars you like :smile:.
 ### Manual Installation
 
 First, download the latest SAML Raider version:
-[saml-raider-2.1.0.jar](https://github.com/SAMLRaider/SAMLRaider/releases/download/v2.1.0/saml-raider-2.1.0.jar).
+[saml-raider-2.1.1.jar](https://github.com/SAMLRaider/SAMLRaider/releases/download/v2.1.1/saml-raider-2.1.0.jar).
 Then, start Burp Suite and click in the `Extensions` tab on `Add`. Choose the
 SAML Raider JAR file to install it and you are ready to go.
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java-library"
 }
 
-version = "2.1.0"
+version = "2.1.1"
 
 repositories {
 	mavenCentral()

--- a/src/main/java/application/SamlMessageEncoder.java
+++ b/src/main/java/application/SamlMessageEncoder.java
@@ -22,6 +22,10 @@ public class SamlMessageEncoder {
             }
         }
 
+        if(message == null) {
+            message = "";
+        }
+
         byte[] byteMessage = message.getBytes(StandardCharsets.UTF_8);
 
         if (isInflated) {


### PR DESCRIPTION
This PR fixes a null pointer exception when editing invalid XML.

Repro steps:
1. Intercept a SAML response
2. Ensure RAW mode is not checked
3. Add some invalid XML at the top of the document:
```
<!DOCTYPE xml [
  <![CDATA[<!ENTITY name "value">]]>
]>
```
5. Attempt to forward request

Results in Null pointer exception

The fix is make message a blank string when it is null avoiding the null pointer.