### PR TITLE
Infinity loop at compression fix

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,12 +2,12 @@ Uuid: c61cfa893bb14db4b01775554f7b802e
 ExtensionType: 1
 Name: SAML Raider
 RepoName: saml-raider
-ScreenVersion: 2.1.0
-SerialVersion: 18
+ScreenVersion: 2.1.1
+SerialVersion: 19
 MinPlatformVersion: 0
 ProOnly: False
 Author: Roland Bischofberger / Emanuel Duss / Tobias Hort-Giess
 ShortDescription: Provides a SAML message editor and a certificate management tool to help with testing SAML infrastructures.
-EntryPoint: build/libs/saml-raider-2.1.0.jar
+EntryPoint: build/libs/saml-raider-2.1.1.jar
 BuildCommand: ./gradlew jar
 SupportedProducts: Pro, Community

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Don't forget to rate our extension with as many stars you like :smile:.
 ### Manual Installation
 
 First, download the latest SAML Raider version:
-[saml-raider-2.1.0.jar](https://github.com/SAMLRaider/SAMLRaider/releases/download/v2.1.0/saml-raider-2.1.0.jar).
+[saml-raider-2.1.1.jar](https://github.com/SAMLRaider/SAMLRaider/releases/download/v2.1.1/saml-raider-2.1.1.jar).
 Then, start Burp Suite and click in the `Extensions` tab on `Add`. Choose the
 SAML Raider JAR file to install it and you are ready to go.
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id "java-library"
 }
 
-version = "2.1.0"
+version = "2.1.1"
 
 repositories {
 	mavenCentral()

--- a/src/main/java/application/SamlMessageDecoder.java
+++ b/src/main/java/application/SamlMessageDecoder.java
@@ -32,20 +32,23 @@ public class SamlMessageDecoder {
         boolean isInflated = true;
         boolean isGZip = true;
 
-       var httpHelpers = new HTTPHelpers();
-
-        try {
-            byte[] inflated = httpHelpers.decompress(base64Decoded, true);
-            return new DecodedSAMLMessage(new String(inflated, StandardCharsets.UTF_8), isInflated, isGZip);
-        } catch (DataFormatException e) {
-            isGZip = false;
-        }
-
-        try {
-            byte[] inflated = httpHelpers.decompress(base64Decoded, false);
-            return new DecodedSAMLMessage(new String(inflated, StandardCharsets.UTF_8), isInflated, isGZip);
-        } catch (DataFormatException e) {
+        if (base64Decoded.length == 0) {
             isInflated = false;
+            isGZip = false;
+        } else {
+            var httpHelpers = new HTTPHelpers();
+            try {
+                byte[] inflated = httpHelpers.decompress(base64Decoded, true);
+                return new DecodedSAMLMessage(new String(inflated, StandardCharsets.UTF_8), isInflated, isGZip);
+            } catch (DataFormatException e) {
+                isGZip = false;
+            }
+            try {
+                byte[] inflated = httpHelpers.decompress(base64Decoded, false);
+                return new DecodedSAMLMessage(new String(inflated, StandardCharsets.UTF_8), isInflated, isGZip);
+            } catch (DataFormatException e) {
+                isInflated = false;
+            }
         }
 
         return new DecodedSAMLMessage(new String(base64Decoded, StandardCharsets.UTF_8), isInflated, isGZip);

--- a/src/main/java/helpers/HTTPHelpers.java
+++ b/src/main/java/helpers/HTTPHelpers.java
@@ -9,11 +9,8 @@ import java.util.zip.Inflater;
 
 public class HTTPHelpers {
 
-    /**
-     * <a href="http://qupera.blogspot.ch/2013/02/howto-compress-and-uncompress-java-byte.html">Source</a>
-     */
     public byte[] decompress(byte[] data, boolean gzip) throws DataFormatException {
-        if (data == null || data.length == 0) {
+        if (data.length == 0) {
             return new byte[0];
         }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
@@ -32,11 +29,8 @@ public class HTTPHelpers {
         }
     }
 
-    /**
-     * <a href="http://qupera.blogspot.ch/2013/02/howto-compress-and-uncompress-java-byte.html">Source</a>
-     */
     public byte[] compress(byte[] data, boolean gzip) {
-        if (data == null || data.length == 0) {
+        if (data.length == 0) {
             return new byte[0];
         }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {

--- a/src/main/java/helpers/HTTPHelpers.java
+++ b/src/main/java/helpers/HTTPHelpers.java
@@ -13,6 +13,9 @@ public class HTTPHelpers {
      * <a href="http://qupera.blogspot.ch/2013/02/howto-compress-and-uncompress-java-byte.html">Source</a>
      */
     public byte[] decompress(byte[] data, boolean gzip) throws DataFormatException {
+        if (data == null || data.length == 0) {
+            throw new DataFormatException("Cannot decompress empty input.");
+        }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
             Inflater inflater = new Inflater(gzip);
             inflater.setInput(data);
@@ -33,6 +36,9 @@ public class HTTPHelpers {
      * <a href="http://qupera.blogspot.ch/2013/02/howto-compress-and-uncompress-java-byte.html">Source</a>
      */
     public byte[] compress(byte[] data, boolean gzip) {
+        if (data == null || data.length == 0) {
+            return new byte[0];
+        }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
             Deflater deflater = new Deflater(5, gzip);
             deflater.setInput(data);

--- a/src/main/java/helpers/HTTPHelpers.java
+++ b/src/main/java/helpers/HTTPHelpers.java
@@ -14,7 +14,7 @@ public class HTTPHelpers {
      */
     public byte[] decompress(byte[] data, boolean gzip) throws DataFormatException {
         if (data == null || data.length == 0) {
-            throw new DataFormatException("Cannot decompress empty input.");
+            return new byte[0];
         }
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length)) {
             Inflater inflater = new Inflater(gzip);

--- a/src/test/java/application/HTTPHelpersTest.java
+++ b/src/test/java/application/HTTPHelpersTest.java
@@ -6,7 +6,7 @@ import java.util.Base64;
 import java.util.zip.DataFormatException;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class HTTPHelpersTest {
@@ -27,6 +27,20 @@ public class HTTPHelpersTest {
         String result = Base64.getEncoder().encodeToString(valueCompressed);
         result = result.replaceAll("\\r?\\n", "");
         assertEquals(compressed, result);
+    }
+
+    @Test
+    public void testEmptyInflate() {
+        assertThrows(DataFormatException.class, () -> {
+            helpers.decompress(new byte[]{}, true);
+        });
+    }
+    @Test
+    public void testEmptyDeflate() {
+        byte[] emptyInput = new byte[0];
+        byte[] compressed = helpers.compress(emptyInput, true);
+        assertNotNull(compressed, "Compressed output should not be null");
+        assertEquals(0, compressed.length, "Compressed output of empty input should be empty");
     }
 
 }

--- a/src/test/java/application/HTTPHelpersTest.java
+++ b/src/test/java/application/HTTPHelpersTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 public class HTTPHelpersTest {
+
     HTTPHelpers helpers = new HTTPHelpers();
 
     String compressed = "fVLLasMwEPwVo3siWXb8EI6hNJdAemlCDr0UPdaNwZaEV4J+fh2H0gRKTmJ3NLOzIzUox8GLg/tyMbwDemcRku9xsCgWaEviZIWT2KOwcgQUQYvjy9tB8DUTfnLBaTeQO8pzhkSEKfTOkmS/25LPQmpV6jwtOYNu0zGmc53xrmBpoVVWm7JLNatlVVUkOcOEM3NLZqGZjhhhbzFIG+YWSzcrVq7S+pRmIssF4x8k2QGG3sqwsC4heEHp1WOEAT3FfvQDXGs6OhMHWPuLX3CKt5OvhiWZBTDQyTiEFfp5uP0N6+TmLWpeVEqV3DCjeJ5DV9baZGxub8CAUgagLE2t6oq0zVVYLO6n9tFTb3xD7+Hm9jzHIEPEx+rVGUjOcqY9DxyX2+IYtQZEQtvbhD9R+t8XaH8A";
@@ -30,11 +31,13 @@ public class HTTPHelpersTest {
     }
 
     @Test
-    public void testEmptyInflate() {
-        assertThrows(DataFormatException.class, () -> {
-            helpers.decompress(new byte[]{}, true);
-        });
+    public void testEmptyInflate() throws Exception {
+        byte[] emptyInput = new byte[0];
+        byte[] decompressed = helpers.decompress(emptyInput, true);
+        assertNotNull(decompressed, "Decompressed output should not be null");
+        assertEquals(0, decompressed.length, "Deompressed output of empty input should be empty");
     }
+
     @Test
     public void testEmptyDeflate() {
         byte[] emptyInput = new byte[0];


### PR DESCRIPTION
An error occurs when SAML Raider tries to decompress an empty SAMLRequest parameter. Specifically, the following code:
```java
Inflater inflater = new Inflater(gzip);
inflater.setInput(data);
```
...enters an infinite loop because `inflater.finished()` never returns true on empty input, and inflate() returns 0 indefinitely, causing the UI to freeze. To prevent this, you may consider updating the decompression logic to explicitly handle empty input — for example, by returning new byte[0] early or throwing an exception. This might require some additional safeguards or refactoring depending on usage.